### PR TITLE
Add 2025 Scheme Workshop, archive 2024

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -15,7 +15,7 @@
     Functional<br />
     Programming<br />
     Workshop</div>
-  <a id="latest-year" href="https://icfp24.sigplan.org/home/scheme-2024">2024</a>
+  <a id="latest-year" href="https://icfp25.sigplan.org/home/scheme-2025">2025</a>
   <table id="past-years">
     <tr>
       <td><a href="2000/">2000</a></td>
@@ -45,6 +45,8 @@
       <td><a href="https://icfp21.sigplan.org/home/scheme-2021">2021</a></td>
       <td><a href="https://icfp22.sigplan.org/home/scheme-2022">2022</a></td>
       <td><a href="https://icfp23.sigplan.org/home/scheme-2023">2023</a></td></tr>
+    <tr>
+      <td><a href="https://icfp24.sigplan.org/home/scheme-2024">2024</a></td></tr>
     <tr>
       <td id="steering-committee" class="sf-font-style" colspan="6"><a href="sc.html">Steering Committee</a></td></tr></table></div>
 


### PR DESCRIPTION
Moves the 2024 edition into the list of old ones, and adds the 2025 edition. 

Now that all future editions are all being hosted the same way, I wonder if someone cleverer than I can automate away needing to do this manual update 1x/year.